### PR TITLE
Unshift 'node' onto process.argv

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -214,7 +214,7 @@ function monkeyPatchNodejs(node, next) {
 			if(~content.indexOf('nexe')) return this();
 
 			fs.writeFile(nodejsPath,
-			content.replace(/\(function\(process\) \{/,'(function(process){ \n process._eval = \'require("nexe");\'; '),
+			content.replace(/\(function\(process\) \{/,'(function(process) {\n  process._eval = \'require("nexe");\';\n  process.argv.unshift("node");\n'),
 			"utf8",
 			this);
 		}),


### PR DESCRIPTION
The node executable is the first value in argv. This was missing after compiling.

Fixes #23.
