### PR TITLE
Add platform detection for openbsd & freebsd compatibility

### DIFF
--- a/lib/exe.js
+++ b/lib/exe.js
@@ -9,6 +9,7 @@ ProgressBar   = require("progress"),
 child_process = require("child_process"),
 glob          = require("glob"),
 sardines      = require("sardines"),
+os	      = require("os"),
 spawn         = child_process.spawn;
 
 /**
@@ -176,7 +177,11 @@ function _getNodeCompiler (nodeFileDir, complete) {
 				configure.stdout.pipe(process.stdout);
 				configure.stderr.pipe(process.stderr);
 				configure.on("close", function () {
-					var make = spawn("make", [], { cwd: dir });
+					var platformMake = "make";
+					if (os.platform().match(/bsd$/) != null) {
+						platformMake = "gmake";
+					}
+					var make = spawn(platformMake, [], { cwd: dir });
 					make.stdout.pipe(process.stdout);
 					make.stderr.pipe(process.stderr);
 					make.on("close", function () {


### PR DESCRIPTION
Just uses gmake instead of make if the OS platform ends with bsd.
