### PR TITLE
Prevent Windows Paths from causing issues.

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -89,7 +89,7 @@ function bundle (input, complete) {
         var req = "function (require, module, exports) { \n" + dep.source + "}"
 
 
-        dbuffer.push("'" + dep.id + "': ["+req+", "+!!dep.entry+", "+JSON.stringify(dep.deps)+"]")
+        dbuffer.push(JSON.stringify(dep.id) + ": ["+req+", "+!!dep.entry+", "+JSON.stringify(dep.deps)+"]")
       }
 
 


### PR DESCRIPTION
Serializes `dep.id` from containing incompatible unserialized Windows paths.
