### PR TITLE
Patch to support wildcards in browserify options

### DIFF
--- a/lib/exe.js
+++ b/lib/exe.js
@@ -948,6 +948,24 @@ function _logProgress(req) {
 }
 
 /**
+ * Expand require/exclude/path options with wildcards
+ */
+
+function _globPath(browOpt,options) {
+  var outputPath = [];
+  
+  browOpt.forEach(function(browPath) {
+    // Only parse option with a wildcard
+    if(browPath.indexOf('*')>-1){
+      outputPath = outputPath.concat(glob.sync(browPath, options));
+    }else{
+      outputPath.push(browPath);
+    }
+  });
+  return outputPath;
+}
+
+/**
  * Attempt to parse the package.json for nexe information.
  *
  * @param {string} path - path to package.json
@@ -997,11 +1015,14 @@ exports.package = function(path, options) {
     framework: (_package.nexe.runtime.framework || options.f)
   }
 
+  // glob options (TODO: include in package.json)
+  var globOpts = [];
+  
   // browserify options
   if(_package.nexe.browserify !== undefined) {
-    obj.browserifyRequires = (_package.nexe.browserify.requires || []);
-    obj.browserifyExcludes = (_package.nexe.browserify.excludes || []);
-    obj.browserifyPaths    = (_package.nexe.browserify.paths    || []);
+    obj.browserifyRequires = _globPath((_package.nexe.browserify.requires || []),globOpts);
+    obj.browserifyExcludes = _globPath((_package.nexe.browserify.excludes || []),globOpts);
+    obj.browserifyPaths    = _globPath((_package.nexe.browserify.paths    || []),globOpts);
   }
 
   // TODO: get rid of this crappy code I wrote and make it less painful to read.


### PR DESCRIPTION
Expand paths containing wildcards with glob in browserify requires/excludes/paths options.
