### PR TITLE
Express template engine workaround 

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ If it *still* doesn't work, file a bug with what you tried! (also try using `nex
 
 ## Express Issues
 
-After compiling your Express application you find problems with your template engine (jade|pug|ejs|...) not being found:
+If after compiling your Express application you find problems with your template engine (jade, pug, ejs...) not being found:
 
 ```
 Error: No such native module jade

--- a/README.md
+++ b/README.md
@@ -232,6 +232,39 @@ browserify.paths like so:
 
 If it *still* doesn't work, file a bug with what you tried! (also try using `nexe@0.4.2`)
 
+## Express Issues
+
+After compiling your Express application you find problems with your template engine (jade|pug|ejs|...) not being found:
+
+```
+Error: No such native module jade
+   at NativeModule.require (bootstrap_node.js:435:13)
+   at s (nexe.js:1:176)
+   at nexe.js:1:367
+   at new View (nexe.js:8220:30)
+   at EventEmitter.render (nexe.js:4985:12)
+   at ServerResponse.render (nexe.js:6709:7)
+   at nexe.js:52:9
+   at Layer.handle_error (nexe.js:7521:5)
+   at trim_prefix (nexe.js:7113:13)
+   at nexe.js:7083:7
+```
+
+You can workaround it by adding your template engine to your `nexe.browserify.requires` in your `package.json`:
+
+```json
+"nexe": {
+    .......
+    "browserify": {
+        "requires": [ "jade" ]
+    },
+    .......
+}
+```
+
+See the [express demo project](https://github.com/jaredallard/nexe/tree/master/test/express-test) for more information.
+
+
 ## Maintainers
 
 * __Jared Allard__ ([@jaredallard](https://github.com/jaredallard)) &lt;[jaredallard@outlook.com](mailto:jaredallard@outlook.com)&gt; (Active)

--- a/test/express-test/package.json
+++ b/test/express-test/package.json
@@ -19,9 +19,12 @@
     "output": "test.nex",
     "temp": "../src",
     "debug": false,
+    "browserify": {
+        "requires": [ "jade" ]
+    },
     "runtime": {
       "framework": "node",
-      "version": "5.10.0",
+      "version": "4.5.0",
       "ignoreFlags": true
     }
   }


### PR DESCRIPTION
See https://github.com/jaredallard/nexe/issues/250

IMPORTANT: This is a workaround to fix the issue that Nexe has not being able to load the Express template engine (jade, pug, ejs...). It doesn't fix the issue.

I did not want to implement new features before consulting Nexe's mantainers, but, could be it useful to include a `nexe.required_modules` list field in `package.json` to allow users to include modules that Nexe may be missing? Or even better, use `dependencies` to know what to install?

I am afraid I don't have enough knowledge of Nexe's source code to know why is Nexe not loading the template engine even if it is included in the `dependencies` field of `package.json`
