### PR TITLE
a few fixes found when starting with using package.json

### DIFF
--- a/bin/nexe
+++ b/bin/nexe
@@ -81,7 +81,7 @@ function toAbsolute(pt) {
 }
 
 if (fs.lstatSync(argv.i).isDirectory()) {
-  opts = nexe.package(path.join(argv.i, "package.json"), argv);
+  opts = nexe.package(path.resolve(argv.i, "package.json"), argv);
   nexe.compile(opts, function(error) {
     if (error) {
       return console.log(error.message);

--- a/lib/embed.js
+++ b/lib/embed.js
@@ -61,8 +61,14 @@ function embed(resourceFiles, resourceRoot, options, complete) {
 
   let buffer = "var embeddedFiles = {\n";
   for (let i = 0; i < resourceFiles.length; ++i) {
-    buffer += JSON.stringify(path.relative(resourceRoot, resourceFiles[i])) + ': "';
-    buffer += encode(resourceFiles[i]) + '",\n';
+	if (resourceFiles[i].endsWith("/") || resourceFiles[i].endsWith("\\")){
+		buffer += JSON.stringify(path.relative(resourceRoot, resourceFiles[i])) + ': "';
+		var x = new Buffer("isDirectory");
+		buffer += x.toString('base64') + '",\n';
+	} else {
+		buffer += JSON.stringify(path.relative(resourceRoot, resourceFiles[i])) + ': "';
+		buffer += encode(resourceFiles[i]) + '",\n';
+	}
   }
 
   buffer += "\n};\n\nmodule.exports.keys = function () { return Object.keys(embeddedFiles); }\n\nmodule.exports.get = ";

--- a/lib/exe.js
+++ b/lib/exe.js
@@ -1031,7 +1031,7 @@ exports.package = function(path, options) {
     python: (_package.nexe.python || options.p),
     debug: (_package.nexe.debug || options.d),
     nodeTempDir: (_package.nexe.temp || options.t),
-    framework: (_package.nexe.runtime.framework || options.f)
+    framework: (_package.nexe.runtime.framework || options.F)
   }
 
   // browserify options

--- a/lib/exe.js
+++ b/lib/exe.js
@@ -1017,6 +1017,11 @@ exports.package = function(path, options) {
     _package.nexe.output = _package.nexe.output.replace(/\^\$/, '') // none
   }
 
+  // prevent failures below
+  if(_package.nexe.runtime === undefined) {
+    _package.nexe.runtime = {};
+  }
+  
   // construct the object
   let obj = {
     input: (_package.nexe.input || options.i),

--- a/lib/exe.js
+++ b/lib/exe.js
@@ -1022,7 +1022,7 @@ exports.package = function(path, options) {
     input: (_package.nexe.input || options.i),
     output: (_package.nexe.output || options.o),
     flags: (_package.nexe.runtime.ignoreFlags || (options.f || false)),
-    resourceFiles: (_package.nexe.resourceFiles),
+    resourceFiles: (_package.nexe.resourceFiles || []),
     nodeVersion: (_package.nexe.runtime.version || options.r),
     nodeConfigureArgs: (_package.nexe.runtime.nodeConfigureArgs || []),
     nodeMakeArgs: (_package.nexe.runtime.nodeMakeArgs || []),


### PR DESCRIPTION
A typo (f->F) in argument defaults which caught me out.
Default resourcefiles to [] if not provided (untested).
Add runtime to _package.nexe if it's not present; else the following code dies is nexe.runtime is absent from the package.json
Allow folder names to be embedded;  this is something special to me :).  but it may be useful to others.

I *wish* it was easier to make separate pull requests for separate commits :)  Took the time to commit each change separately, then could not find a way to submit them separately...