### PR TITLE
Fix use of cluster module

### DIFF
--- a/lib/exe.js
+++ b/lib/exe.js
@@ -719,6 +719,7 @@ function _monkeyPatchMainJs(compiler, complete) {
 function startup() {\n\
     process._eval = NativeModule.getSource("nexe");\n\
 ')
+      content = content.replace(/process.nextTick/g, 'setImmediate');
       next(null, content)
     },
     complete

--- a/test/cluster-test/app.js
+++ b/test/cluster-test/app.js
@@ -1,0 +1,61 @@
+var express = require('express');
+var path = require('path');
+var favicon = require('serve-favicon');
+var logger = require('morgan');
+var cookieParser = require('cookie-parser');
+var bodyParser = require('body-parser');
+var jade       = require('jade');
+
+var routes = require('./routes/index');
+var users = require('./routes/users');
+
+var app = express();
+
+// view engine setup
+app.set('views', path.join(__dirname, 'views'));
+app.set('view engine', 'jade');
+
+// uncomment after placing your favicon in /public
+//app.use(favicon(path.join(__dirname, 'public', 'favicon.ico')));
+app.use(logger('dev'));
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({ extended: false }));
+app.use(cookieParser());
+app.use(express.static(path.join(__dirname, 'public')));
+
+app.use('/', routes);
+app.use('/users', users);
+
+// catch 404 and forward to error handler
+app.use(function(req, res, next) {
+  var err = new Error('Not Found');
+  err.status = 404;
+  next(err);
+});
+
+// error handlers
+
+// development error handler
+// will print stacktrace
+if (app.get('env') === 'development') {
+  app.use(function(err, req, res, next) {
+    res.status(err.status || 500);
+    res.render('error', {
+      message: err.message,
+      error: err
+    });
+  });
+}
+
+// production error handler
+// no stacktraces leaked to user
+app.use(function(err, req, res, next) {
+  res.status(err.status || 500);
+  res.render('error', {
+    message: err.message,
+    error: {}
+  });
+});
+
+
+module.exports = app;

--- a/test/cluster-test/bin/www
+++ b/test/cluster-test/bin/www
@@ -97,5 +97,5 @@ function onListening() {
   debug('Listening on ' + bind);
 }
 
-process.stdout.write('true');
+process.stdout.write(''+cluster.isWorker);
 process.exit(0);

--- a/test/cluster-test/bin/www
+++ b/test/cluster-test/bin/www
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+
+/**
+ * Module dependencies.
+ */
+
+var cluster = require('cluster');
+
+if(cluster.isMaster) {
+  cluster.setupMaster();
+  cluster.fork();
+  return;
+}
+
+var app = require('../app');
+var debug = require('debug')('express-test:server');
+var http = require('http');
+
+/**
+ * Get port from environment and store in Express.
+ */
+
+var port = normalizePort(process.env.PORT || '3000');
+app.set('port', port);
+
+/**
+ * Create HTTP server.
+ */
+
+var server = http.createServer(app);
+
+/**
+ * Listen on provided port, on all network interfaces.
+ */
+
+server.listen(port);
+server.on('error', onError);
+server.on('listening', onListening);
+
+/**
+ * Normalize a port into a number, string, or false.
+ */
+
+function normalizePort(val) {
+  var port = parseInt(val, 10);
+
+  if (isNaN(port)) {
+    // named pipe
+    return val;
+  }
+
+  if (port >= 0) {
+    // port number
+    return port;
+  }
+
+  return false;
+}
+
+/**
+ * Event listener for HTTP server "error" event.
+ */
+
+function onError(error) {
+  if (error.syscall !== 'listen') {
+    throw error;
+  }
+
+  var bind = typeof port === 'string'
+    ? 'Pipe ' + port
+    : 'Port ' + port;
+
+  // handle specific listen errors with friendly messages
+  switch (error.code) {
+    case 'EACCES':
+      console.error(bind + ' requires elevated privileges');
+      process.exit(1);
+      break;
+    case 'EADDRINUSE':
+      console.error(bind + ' is already in use');
+      process.exit(1);
+      break;
+    default:
+      throw error;
+  }
+}
+
+/**
+ * Event listener for HTTP server "listening" event.
+ */
+
+function onListening() {
+  var addr = server.address();
+  var bind = typeof addr === 'string'
+    ? 'pipe ' + addr
+    : 'port ' + addr.port;
+  debug('Listening on ' + bind);
+}
+
+process.stdout.write('true');
+process.exit(0);

--- a/test/cluster-test/package.json
+++ b/test/cluster-test/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "express-test",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "start": "node ./bin/www"
+  },
+  "dependencies": {
+    "body-parser": "~1.13.2",
+    "cookie-parser": "~1.3.5",
+    "debug": "~2.2.0",
+    "express": "~4.13.1",
+    "jade": "~1.11.0",
+    "morgan": "~1.6.1",
+    "serve-favicon": "~2.3.0"
+  },
+  "nexe": {
+    "input": "bin/www",
+    "output": "test.nex",
+    "temp": "../src",
+    "debug": false,
+    "runtime": {
+      "framework": "node",
+      "version": "5.10.0",
+      "ignoreFlags": true
+    }
+  }
+}

--- a/test/cluster-test/public/stylesheets/style.css
+++ b/test/cluster-test/public/stylesheets/style.css
@@ -1,0 +1,8 @@
+body {
+  padding: 50px;
+  font: 14px "Lucida Grande", Helvetica, Arial, sans-serif;
+}
+
+a {
+  color: #00B7FF;
+}

--- a/test/cluster-test/routes/index.js
+++ b/test/cluster-test/routes/index.js
@@ -1,0 +1,9 @@
+var express = require('express');
+var router = express.Router();
+
+/* GET home page. */
+router.get('/', function(req, res, next) {
+  res.render('index', { title: 'Express' });
+});
+
+module.exports = router;

--- a/test/cluster-test/routes/users.js
+++ b/test/cluster-test/routes/users.js
@@ -1,0 +1,9 @@
+var express = require('express');
+var router = express.Router();
+
+/* GET users listing. */
+router.get('/', function(req, res, next) {
+  res.send('respond with a resource');
+});
+
+module.exports = router;

--- a/test/cluster-test/views/error.jade
+++ b/test/cluster-test/views/error.jade
@@ -1,0 +1,6 @@
+extends layout
+
+block content
+  h1= message
+  h2= error.status
+  pre #{error.stack}

--- a/test/cluster-test/views/index.jade
+++ b/test/cluster-test/views/index.jade
@@ -1,0 +1,5 @@
+extends layout
+
+block content
+  h1= title
+  p Welcome to #{title}

--- a/test/cluster-test/views/layout.jade
+++ b/test/cluster-test/views/layout.jade
@@ -1,0 +1,7 @@
+doctype html
+html
+  head
+    title= title
+    link(rel='stylesheet', href='/stylesheets/style.css')
+  body
+    block content

--- a/test/test.js
+++ b/test/test.js
@@ -126,6 +126,8 @@ const runTest = function(test, args, cb) {
       return cb(false);
     }
   });
+
+  setTimeout( function() { testinst && testinst.kill() }, 5e3).unref();
 }
 
 console.log('NOTICE: The first test may take awhile as it may compile Node.js');
@@ -142,6 +144,24 @@ after(function() {
  **/
 describe('nexe can bundle express', function() {
   let testname = 'express-test';
+
+  describe('build', function () {
+    it('compiles without errors', function (next) {
+      compileTest(testname, function(err) {
+        return next(err);
+      });
+    });
+
+    it('runs successfully', function(next) {
+      runTest(testname, function(err) {
+        return next(err);
+      });
+    });
+  });
+});
+
+describe('nexe can cluster', function() {
+  let testname = 'cluster-test';
 
   describe('build', function () {
     it('compiles without errors', function (next) {


### PR DESCRIPTION
This PR fixes the cluster module with nexe (tested with node 6 and 5).

Although... I'm not entirely sure why...

Without the extra `replace` a new worker will fork, but then hangs and doesn't ever actually do anything.

With this patch the worker works as expected.

I sorta stumbled across the fix because I noticed the diff (process.nextTick vs setImmediate) from https://github.com/nodejs/node/pull/8821 and thought I'd see if it did anything. Apparently it did.

Absolutely no problem if you don't want to merge this (and I'd understand if you didn't because it's a bit "odd"), but thought I'd create a PR in case it helps anyone :-)

Happy to change/clean it too :-)

(The `cluster-test` is just the `express-test` with a `cluster.fork()`...)