### PR TITLE
Example of using Musl for a static build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,5 +51,8 @@
   "devDependencies": {
     "mocha": "^2.4.5",
     "mocha-circleci-reporter": "0.0.1"
+  },
+  "optionalDependencies": {
+    "node-musl": "^0.0.1"
   }
 }

--- a/test/static-test/index.js
+++ b/test/static-test/index.js
@@ -1,0 +1,9 @@
+let pass = false;
+try {
+  process.dlopen('', '');
+} catch(e) {
+  // musl error message
+  if(e.message === 'Dynamic loading not supported') pass = true;
+}
+
+console.log(pass ? 'true' : 'false');

--- a/test/static-test/package.json
+++ b/test/static-test/package.json
@@ -1,0 +1,17 @@
+{
+	"name": "flags-test",
+	"nexe": {
+		"input": "./index.js",
+		"output": "test.nex",
+		"temp": "../src",
+		"runtime": {
+			"framework": "node",
+			"version": "6.10.0",
+			"ignoreFlags": false,
+			"node-args": "",
+			"nodeConfigureArgs": [
+				"--fully-static"
+			]
+		}
+	}
+}

--- a/test/test.js
+++ b/test/test.js
@@ -247,3 +247,35 @@ describe('nexe supports js-yaml test', function() {
     });
   });
 });
+
+let musl;
+try {
+  musl = require('node-musl');
+} catch(e) {
+  if(e.code !== 'MODULE_NOT_FOUND') throw e;
+  console.error('Skipping musl test because node-musl is not installed.');
+} // unsupported platform or node-musl not installed
+
+(musl ? describe : describe.skip)('nexe can build in a static manner using Musl', function() {
+  let testname = 'static-test';
+
+  describe('build', function () {
+    let env;
+    it('compiles without errors', function (next) {
+      env = Object.assign({}, process.env);
+      musl.setExports();
+      compileTest(testname, function(err) {
+        return next(err);
+      });
+    });
+
+    it('runs successfully', function(next) {
+      runTest(testname, function(err) {
+        Object.keys(process.env)
+          .concat(Object.keys(env))
+          .forEach( (k) => env.hasOwnProperty(k) ? process.env[k] = env[k] : delete process.env[k]);
+        return next(err);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Thought this might be of interest; it uses a Musl toolchain to build a completely static version of Node (Glib doesn't do completely static builds).

Musl is only available on Linux though.

An example of a build script:

```
#!/usr/bin/env node

const nexe = require('nexe')
const os = require('os')

require('node-musl').setExports()

nexe.compile({
  input: 'input.js',
  python: process.env.PYTHON || 'python2',
  nodeVersion: '6.10.0',
  framework: 'node',
  flags: true,
  output: 'out.nex',
  nodeTempDir: 'tmp',
  nodeMakeArgs: ['-j', os.cpus().length + 1],
  nodeConfigureArgs: [
    '--without-dtrace',
    '--without-npm',
    '--without-inspector',
    '--without-etw',
    '--without-perfctr',
    '--fully-static',
  ],
}, (err) => {
  if(err) throw err
})

```