### PR TITLE
Prepend the Python path for Windows for overriding

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -44,7 +44,7 @@ export class NexeCompiler {
 
     if (python) {
       if (isWindows) {
-        this.env.PATH = this.env.PATH + ';"' + dequote(normalize(python)) + '"'
+        this.env.PATH = '"' + dequote(normalize(python)) + '";' + this.env.PATH
       } else {
         this.env.PYTHON = python
       }


### PR DESCRIPTION
Setting the `python` option did not work on Windows for me as I already had the Python 3.x directory path in my `PATH` variable for my normal Python usage.  In order to allow the `python` option to override that, it must be _**prepended**_ to the existing `PATH` value rather than being appended.