### PR TITLE
Corrected chain-loading path in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-const nexe = require('./lib/nexe')
+const nexe = require('./src/nexe')
 
 module.exports = nexe
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "git://github.com/nexe/nexe.git"
   },
   "files": [
-    "lib"
+    "src"
   ],
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Otherwise I get:

```
module.js:327
    throw err;
    ^

Error: Cannot find module './lib/nexe'
    at Function.Module._resolveFilename (module.js:325:15)
    at Function.Module._load (module.js:276:25)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (C:\git\Observer\Node\ObsNode\node_modules\nexe\index.js:2:14)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Module.require (module.js:353:17)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
```