### PR TITLE
Prepend the Python path for Windows for overriding (V1-EOL)

### DIFF
--- a/lib/exe.js
+++ b/lib/exe.js
@@ -471,8 +471,8 @@ function _getNodeCompiler(nodeFileDir, nodeConfigureArgs, nodeMakeArgs, nodeVCBu
           var newEnv = process.env
 
           if (isPy !== "python") {
-            // add the dir of the suposed python exe to path
-            newEnv.path = process.env.PATH + ";" + path.dirname(isPy)
+            // add the dir of the supposed python exe to path
+            newEnv.path = path.dirname(isPy) + ";" + process.env.PATH
           }
 
           if (!nodeVCBuildArgs || !nodeVCBuildArgs.length) {


### PR DESCRIPTION
Setting the `python` option did not work on Windows for me as I already had the Python 3.x directory path in my `PATH` variable for my normal Python usage.  In order to allow the `python` option to override that, it must be _**prepended**_ to the existing `PATH` value rather than being appended.

Same as previously merged PR #336, except targeting the `V1-EOL` branch.