### PR TITLE
Add newline to end of command line help text

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -131,7 +131,7 @@ nexe --help              CLI OPTIONS
        --silent                             -- disable logging
        --verbose                            -- set logging to verbose
 
-       -* variable key name                 * option can be used more than once`.trim()
+       -* variable key name                 * option can be used more than once`.trim() + '\n'
 
 function flattenFilter(...args: any[]): string[] {
   return ([] as string[]).concat(...args).filter(x => x)


### PR DESCRIPTION
Without this, when you run `nexe --help` in a terminal, your shell prompt will be on the same line as `option can be used more than once`.