### PR TITLE
Show process output when loglevel is verbose.

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -136,7 +136,7 @@ export class NexeCompiler<T extends NexeOptions = NexeOptions> {
       spawn(command, args, {
         cwd: this.src,
         env: this.env,
-        stdio: 'ignore'
+        stdio: this.options.loglevel === 'verbose' ? 'inherit' : 'ignore'
       })
         .once('error', reject)
         .once('close', (code: number) => {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -6,10 +6,12 @@ const frameLength = 120
 export interface LogStep {
   modify(text: string, color?: string): void
   log(text: string, color?: string): void
+  pause(): void
+  resume(): void
 }
 
 export class Logger {
-  private verbose: boolean
+  public verbose: boolean
   private silent: boolean
   private ora: any
   private modify: Function
@@ -48,7 +50,7 @@ export class Logger {
 
   step(text: string, method: string = 'succeed'): LogStep {
     if (this.silent) {
-      return { modify() {}, log() {} }
+      return { modify() {}, log() {}, pause() {}, resume() {} }
     }
     if (!this.ora.id) {
       this.ora.start().text = text
@@ -62,7 +64,9 @@ export class Logger {
 
     return {
       modify: this.modify,
-      log: this.verbose ? this.write : this.modify
+      log: this.verbose ? this.write : this.modify,
+      pause: () => this.ora.stopAndPersist(),
+      resume: () => this.ora.start()
     } as LogStep
   }
 }


### PR DESCRIPTION
Personally, I find it useful to see the build process output (I was debugging some issues initially, but just generally useful to know what's happening).

This is just a simple PR to show the external process output when the log level is set to verbose.

I'd initially considered adding a `trace` type log level, but my current thinking is that keeping the number of log levels small is nicer, and if a user asks for `verbose` then getting this output is useful. It was also just simpler as a "thoughts on doing this?" PR :-)