### PR TITLE
Remove the ghToken for binary download

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -196,6 +196,8 @@ export class NexeCompiler<T extends NexeOptions = NexeOptions> {
       throw new Error(`${assetName} not available, create it using the --build flag`)
     }
     const filename = this.getNodeExecutableLocation(target)
+    // Remove the authorization, as the download is done via amazon S3 and does not need the token
+    delete downloadOptions.headers.Authorization
     await download(asset.browser_download_url, dirname(filename), downloadOptions).on(
       'response',
       (res: IncomingMessage) => {


### PR DESCRIPTION
The github token is only needed for the API access and will confuse amazon S3 when it is passed to the download:

```
<?xml version="1.0" encoding="UTF-8"?>\n<Error><Code>InvalidArgument</Code><Message>Only one auth mechanism allowed; only the X-Amz-Algorithm query parameter, Signature query string parameter or the Authorization header should be specified</Message><ArgumentName>Authorization</ArgumentName><ArgumentValue>token herebesecrettoken</ArgumentValue><RequestId>7CCDB87CF1347C29</RequestId><HostId>xyyeVP5ImwDePFMXAZheNYLnXQBsVCka4U6KLWKCjynHNpQZxzfBdl4sRfUbORSul8c8YNwux8w=</HostId></Error>
```

Refs #425