### PR TITLE
Fix regex in node.rc patch

### DIFF
--- a/src/patches/node-rc.ts
+++ b/src/patches/node-rc.ts
@@ -13,7 +13,7 @@ export default async function nodeRc(compiler: NexeCompiler, next: () => Promise
     const isVar = /^[A-Z_]+$/.test(value)
     value = isVar ? value : `"${value}"`
     file.contents = file.contents.replace(
-      new RegExp(`VALUE "${key}",*`),
+      new RegExp(`VALUE "${key}",.*`),
       `VALUE "${key}", ${value}`
     )
   })


### PR DESCRIPTION
Hi there. I've got an issue with compiling nodejs and i started to dig in and found out that the regex in node.rc patch is invalid.
https://github.com/nexe/nexe/blob/719804eb2fc695d388d5b15cf98a36618368c6a1/src/patches/node-rc.ts#L16
It matches the character `,` literally zero or unlimited times.
And the result was `VALUE "CompanyName", "New company" "Node.js"`
A small pull request with a tiiinyy fix.