### PR TITLE
Don't short circuit NODE_OPTIONS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,9 @@ compile({
  - #### `clean: boolean`
     - If included, nexe will remove temporary files for the accompanying configuration and exit
  - #### `enableNodeCli: boolean`
-    - Enable the original Node CLI (will prevent application cli from working)
+    - Enable the original Node CLI (will prevent application cli from working).
+    - Node CLI arguments passed via the [NODE_OPTIONS](https://nodejs.org/api/cli.html#cli_node_options_options) environment
+      variable will still be processed. NODE_OPTIONS support can be disabled with the `--without-node-options` configure flag.
     - default: `false`
   - #### `fakeArgv: boolean`
     - fake the entry point file name (`process.argv[1]`). If nexe was used with stdin this will be `'[stdin]'`. 

--- a/src/patches/disable-node-cli.ts
+++ b/src/patches/disable-node-cli.ts
@@ -10,7 +10,11 @@ export default async function disableNodeCli(compiler: NexeCompiler, next: () =>
   await compiler.replaceInFileAsync(
     'src/node.cc',
     `${nodeccMarker} '-'`,
-    `(${nodeccMarker} is_env ? '-' : ']')`
+    // allow NODE_OPTIONS, introduced in 8.0
+    parseInt(compiler.target.version.split('.')[0]) >= 8
+      ? `(${nodeccMarker} is_env ? '-' : ']')`
+      : `(${nodeccMarker} ']')`
   )
+
   return next()
 }

--- a/src/patches/disable-node-cli.ts
+++ b/src/patches/disable-node-cli.ts
@@ -5,8 +5,12 @@ export default async function disableNodeCli(compiler: NexeCompiler, next: () =>
     return next()
   }
 
-  const nodeccMarker = "argv[index][0] == '-'"
+  const nodeccMarker = 'argv[index][0] =='
 
-  await compiler.replaceInFileAsync('src/node.cc', nodeccMarker, nodeccMarker.replace('-', ']'))
+  await compiler.replaceInFileAsync(
+    'src/node.cc',
+    `${nodeccMarker} '-'`,
+    `(${nodeccMarker} is_env ? '-' : ']')`
+  )
   return next()
 }


### PR DESCRIPTION
The current `disable-node-cli` patch disables all argument parsing.

This patch changes that patch to disable the argv parsing, but allow the NODE_OPTIONS parsing (is_env is true in that case).

This can be useful to allow debugging, eg `NODE_OPTIONS=--inspect ./out.nexe`.

The NODE_OPTIONS support can be disabled with the `--without-node-options` configure flag.

Happy to make any changes :-)