### PR TITLE
Fix compilation when `stdin` is not a TTY.

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -87,7 +87,7 @@ const alias = {
   'fake-argv': 'fakeArgv',
   'gh-token': 'ghToken'
 }
-const argv = parseArgv(process.argv, { alias, default: { ...defaults, enableStdIn: true } })
+const argv = parseArgv(process.argv, { alias, default: { ...defaults, enableStdIn: false } })
 const g = c.gray
 let help = `
 ${c.bold('nexe <entry-file> [options]')}

--- a/src/steps/cli.ts
+++ b/src/steps/cli.ts
@@ -37,7 +37,7 @@ function getStdIn(stdin: NodeJS.ReadStream): Promise<string> {
 export default async function cli(compiler: NexeCompiler, next: () => Promise<void>) {
   const { log } = compiler
   let stdInUsed = false
-  if (!process.stdin.isTTY && compiler.options.enableStdIn) {
+  if (!process.stdin.isTTY && (compiler.options.enableStdIn || compiler.options.input === '')) {
     stdInUsed = true
     compiler.input = dequote(await getStdIn(process.stdin))
   }


### PR DESCRIPTION
Don't use `stdin` if `--input` is specified.

Fixes https://github.com/nexe/nexe/issues/467#issuecomment-396635612.
References https://github.com/Homebrew/homebrew-core/pull/28873.