### PR TITLE
Ensure setupManifest is called for stat functions.

### DIFF
--- a/src/steps/shim-fs.ts
+++ b/src/steps/shim-fs.ts
@@ -174,6 +174,7 @@ if (Object.keys(manifest).length) {
       return encoding ? result.toString(encoding) : result
     },
     statSync: function statSync(path: string | Buffer) {
+      setupManifest()
       const stat = ownStat(path)
       if (stat) {
         return stat
@@ -181,6 +182,7 @@ if (Object.keys(manifest).length) {
       return originalStatSync.apply(fs, arguments)
     },
     stat: function stat(path: string | Buffer, callback: any) {
+      setupManifest()
       const stat = ownStat(path)
       if (stat) {
         process.nextTick(() => {


### PR DESCRIPTION
Fixes #485.

The send module (via serve-static, via express.static) calls stat on a file before attempting to send it.

The manifest is not setup in the stat functions so the bundled file is not found.