### PR TITLE
Resource should always we a glob string.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For more CLI options see: `nexe --help`
 
 ### Examples
 
-- `nexe server.js -r public/**/*.html`
+- `nexe server.js -r "public/**/*.html"`
 - `nexe my-bundle.js --no-bundle -o app.exe`
 - `nexe --build`
 - `nexe -t x86-8.0.0`


### PR DESCRIPTION
To avoid confusion regarding the resource glob string, all examples i the readme should be in strings.