### PR TITLE
Stringify `compiler.entrypoint` in shims

### DIFF
--- a/src/steps/shim.ts
+++ b/src/steps/shim.ts
@@ -22,7 +22,7 @@ export default function(compiler: NexeCompiler, next: () => Promise<void>) {
   compiler.shims.push(
     wrap(`
       if (!process.send) {
-        process.argv.splice(1,0, require.resolve("${compiler.entrypoint}"))  
+        process.argv.splice(1,0, require.resolve(${JSON.stringify(compiler.entrypoint)}))  
       }
     `)
   )


### PR DESCRIPTION
This will preserve backslashes on windows instead of producing code like:
```js
require.resolve("mydirundle.js")
```

where the path was actually `mydir\bundle.js`