### PR TITLE
Invalidate binary cache when snapshot file changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nexe",
-  "version": "3.0.0-beta.2",
+  "version": "3.0.0-beta.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This fixes #540 by implementing a way to know whether the binary should be recompiled or not, based on the last modified timestamps of the snapshot file to embed in the binary.

I tested this on my project that has 2 build stages (snapshot doesn't change from 1st to 2nd stage) and it indeed builds a binary the first time but not the 2nd time.