### PR TITLE
Avoid checking DEBUG every log, if set.

### DIFF
--- a/src/fs/patch.ts
+++ b/src/fs/patch.ts
@@ -42,12 +42,9 @@ function shimFs(binary: NexeBinary, fs: any = require('fs')) {
     isDirectory = isFile,
     path = require('path')
 
-  let log = (text: string) => {
-    if ((process.env.DEBUG || '').toLowerCase().includes('nexe:require')) {
-      process.stderr.write('[nexe] - ' + text + '\n')
-    } else {
-      log = noop
-    }
+  let log = (text: string) => true
+  if ((process.env.DEBUG || '').toLowerCase().includes('nexe:require')) {
+    log = (text: string) => process.stderr.write('[nexe] - ' + text + '\n')
   }
 
   const getKey = process.platform.startsWith('win')


### PR DESCRIPTION
Just a small optimisation, if of interest :-) It also makes the code read a little cleaner, imo.

(Previously, if logging was disabled then log would be set to noop on first invocation; but if it was enabled then the if check would be processed every time.)

As another thought, I believe `if(/\bnexe:require\b/i.test(process.env.DEBUG))` is a tempting alternative to the if statement. It avoids the need for the `|| ''` because the test returns false if process.env.DEBUG is undefined; it also avoids the need to toLowerCase the string, and it also avoids clashing with longer strings that match (alas, in this instance that's not a big concern; but for example the existing code would match `mylognexe:require`, however I don't believe that to be "correct").
Just a thought, feel free to entirely ignore it :-) (hence why I didn't put it in the PR :-) )