### PR TITLE
Stats prototype

### DIFF
--- a/src/fs/patch.ts
+++ b/src/fs/patch.ts
@@ -85,32 +85,21 @@ function shimFs(binary: NexeBinary, fs: any = require('fs')) {
     }
   }
 
-  const createStat = function(directoryExtensions: any, fileExtensions?: any) {
-    if (!fileExtensions) {
-      var mode = binary.layout.stat.mode
-      mode |= fs.constants.S_IFDIR
-      mode &= ~fs.constants.S_IFREG
-      return Object.assign(
-        new fs.Stats(),
-        binary.layout.stat,
-        { mode },
-        directoryExtensions,
-        { size: 0 },
-        statTime()
-      )
-    }
-    const size = directoryExtensions[1]
-    return Object.assign(new fs.Stats(), binary.layout.stat, fileExtensions, { size }, statTime())
+  const createStat = function(extensions: any) {
+    return Object.assign(new fs.Stats(), binary.layout.stat, statTime(), extensions)
   }
 
   const ownStat = function(filepath: any) {
     setupManifest()
     const key = getKey(filepath)
     if (directories[key]) {
-      return createStat({ isDirectory, isFile: isNotFile })
+      let mode = binary.layout.stat.mode
+      mode |= fs.constants.S_IFDIR
+      mode &= ~fs.constants.S_IFREG
+      return createStat({ mode, size: 0 })
     }
     if (manifest[key]) {
-      return createStat(manifest[key], { isFile, isDirectory: isNotDirectory })
+      return createStat({ size: manifest[key] })
     }
   }
 

--- a/src/fs/patch.ts
+++ b/src/fs/patch.ts
@@ -87,9 +87,13 @@ function shimFs(binary: NexeBinary, fs: any = require('fs')) {
 
   const createStat = function(directoryExtensions: any, fileExtensions?: any) {
     if (!fileExtensions) {
+      var mode = binary.layout.stat.mode
+      mode |= fs.constants.S_IFDIR
+      mode &= ~fs.constants.S_IFREG
       return Object.assign(
         new fs.Stats(),
         binary.layout.stat,
+        { mode },
         directoryExtensions,
         { size: 0 },
         statTime()

--- a/src/fs/patch.ts
+++ b/src/fs/patch.ts
@@ -87,10 +87,16 @@ function shimFs(binary: NexeBinary, fs: any = require('fs')) {
 
   const createStat = function(directoryExtensions: any, fileExtensions?: any) {
     if (!fileExtensions) {
-      return Object.assign({}, binary.layout.stat, directoryExtensions, { size: 0 }, statTime())
+      return Object.assign(
+        new fs.Stats(),
+        binary.layout.stat,
+        directoryExtensions,
+        { size: 0 },
+        statTime()
+      )
     }
     const size = directoryExtensions[1]
-    return Object.assign({}, binary.layout.stat, fileExtensions, { size }, statTime())
+    return Object.assign(new fs.Stats(), binary.layout.stat, fileExtensions, { size }, statTime())
   }
 
   const ownStat = function(filepath: any) {


### PR DESCRIPTION
Currently the `stat` stub functionality fails with the `esm` module because the `esm` module is using `Reflect` to call some stat functions, eg `isFile`. I created a little demo script to show the functionality and the error. This branch fixes that by ensuring the prototype is correct for the stats stub return objects.

tmp.js

    const fs = require('fs')

    const fileStat = fs.statSync('./tmp.js')

    console.log('--- File ---')
    console.log('isFile: ', fileStat.isFile())
    console.log('Reflect isFile: ', Reflect.apply(fs.Stats.prototype.isFile, fileStat, []))

    console.log('isDirectory: ', fileStat.isDirectory())
    console.log('Reflect isDirectory: ', Reflect.apply(fs.Stats.prototype.isDirectory, fileStat, []))

    const dirStat = fs.statSync('./src')

    console.log('')
    console.log('--- Directory ---')
    console.log('isFile: ', dirStat.isFile())
    console.log('Reflect isFile: ', Reflect.apply(fs.Stats.prototype.isFile, dirStat, []))

    console.log('isDirectory: ', dirStat.isDirectory())
    console.log('Reflect isDirectory: ', Reflect.apply(fs.Stats.prototype.isDirectory, dirStat, []))

Current master:

    $ node --max-old-space-size=2048 index.js --build --resource "./{tmp.js,src/*}" tmp.js
    $ ./tmp
    --- File ---
    isFile:  true
    internal/fs/utils.js:292
      return this._checkModeProperty(S_IFREG);
                  ^

    TypeError: this._checkModeProperty is not a function
        at Object.Stats.isFile (internal/fs/utils.js:292:15)
        at Object.<anonymous> (/mnt/nexe/tmp.js:9:41)
        at Module._compile (internal/modules/cjs/loader.js:734:30)
        at Object.Module._extensions..js (internal/modules/cjs/loader.js:745:10)
        at Module.load (internal/modules/cjs/loader.js:626:32)
        at tryModuleLoad (internal/modules/cjs/loader.js:566:12)
        at Function.Module._load (internal/modules/cjs/loader.js:558:3)
        at Function.Module.runMain (internal/modules/cjs/loader.js:797:12)
        at Object.<anonymous> (/mnt/nexe/tmp:319:30)
        at Module._compile (internal/modules/cjs/loader.js:734:30)

New branch:

    $ node --max-old-space-size=2048 index.js --build --resource "./{tmp.js,src/*}" tmp.js
    $ ./tmp
    --- File ---
    isFile:  true
    Reflect isFile:  true
    isDirectory:  false
    Reflect isDirectory:  false

    --- Directory ---
    isFile:  false
    Reflect isFile:  false
    isDirectory:  true
    Reflect isDirectory:  true