### PR TITLE
More flexiable nexe footer search range to fix digital sign binary fail to launch issue

### DIFF
--- a/src/patches/boot-nexe.ts
+++ b/src/patches/boot-nexe.ts
@@ -1,8 +1,7 @@
 const fs = require('fs'),
   fd = fs.openSync(process.execPath, 'r'),
-  stat = fs.statSync(process.execPath)
-
-const tailSize = Math.min(stat.size, 16000),
+  stat = fs.statSync(process.execPath),
+  tailSize = Math.min(stat.size, 16000),
   tailWindow = Buffer.from(Array(tailSize))
 
 fs.readSync(fd, tailWindow, 0, tailSize, stat.size - tailSize)


### PR DESCRIPTION
Fix Windows binary break after digital sign.
Prebuilt binary still works with this approach.
Credit to  @tamasszarka https://github.com/nexe/nexe/issues/372#issuecomment-438209571