### PR TITLE
Fix snapshot variable names after Node 11

### DIFF
--- a/src/patches/snapshot.ts
+++ b/src/patches/snapshot.ts
@@ -9,7 +9,7 @@ export default async function(compiler: NexeCompiler, next: () => Promise<void>)
     return next()
   }
 
-  const variablePrefix = semverGt(compiler.target.version, '11.0.0') ? 'v8_' : '';
+  const variablePrefix = semverGt(compiler.target.version, '11.0.0') ? 'v8_' : ''
 
   await compiler.replaceInFileAsync(
     compiler.configureScript,
@@ -17,7 +17,10 @@ export default async function(compiler: NexeCompiler, next: () => Promise<void>)
     `def configure_v8(o):\n  o['variables']['${variablePrefix}embed_script'] = r'${resolve(
       cwd,
       snapshot
-    )}'\n  o['variables']['${variablePrefix}warmup_script'] = r'${resolve(cwd, warmup || snapshot)}'`
+    )}'\n  o['variables']['${variablePrefix}warmup_script'] = r'${resolve(
+      cwd,
+      warmup || snapshot
+    )}'`
   )
 
   return next()

--- a/src/patches/snapshot.ts
+++ b/src/patches/snapshot.ts
@@ -8,13 +8,15 @@ export default async function(compiler: NexeCompiler, next: () => Promise<void>)
     return next()
   }
 
+  const variablePrefix = semverGt(compiler.target.version, '11.0.0') ? 'v8_' : '';
+
   await compiler.replaceInFileAsync(
     compiler.configureScript,
     'def configure_v8(o):',
-    `def configure_v8(o):\n  o['variables']['embed_script'] = r'${resolve(
+    `def configure_v8(o):\n  o['variables']['${variablePrefix}embed_script'] = r'${resolve(
       cwd,
       snapshot
-    )}'\n  o['variables']['warmup_script'] = r'${resolve(cwd, warmup || snapshot)}'`
+    )}'\n  o['variables']['${variablePrefix}warmup_script'] = r'${resolve(cwd, warmup || snapshot)}'`
   )
 
   return next()

--- a/src/patches/snapshot.ts
+++ b/src/patches/snapshot.ts
@@ -1,5 +1,6 @@
 import { resolve } from 'path'
 import { NexeCompiler } from '../compiler'
+import { semverGt } from '../util'
 
 export default async function(compiler: NexeCompiler, next: () => Promise<void>) {
   const { snapshot, warmup, cwd } = compiler.options


### PR DESCRIPTION
These changed from e.g. `embed_script` to `v8_embed_script` recently, and I was seeing that my binary didn't contain the snapshot.