### PR TITLE
fix: two windows fs patch bugs

### DIFF
--- a/src/fs/patch.ts
+++ b/src/fs/patch.ts
@@ -157,7 +157,6 @@ function shimFs(binary: NexeBinary, fs: any = require('fs')) {
     ;(manifest[notAFile] as any) = false
     ;(directories[notAFile] as any) = false
     setupManifest = noop
-    console.log('setupManifest: %o', manifest)
   }
 
   //naive patches intended to work for most use cases
@@ -210,10 +209,8 @@ function shimFs(binary: NexeBinary, fs: any = require('fs')) {
 
     readFile: function readFile(filepath: any, options: any, callback: any) {
       setupManifest()
-      console.log('readFile: %o', { filepath, options })
       const entry = manifest[getKey(filepath)]
       if (!entry) {
-        console.log('readFile calling original: %o with %o', originalFsMethods.readFile, arguments)
         return originalFsMethods.readFile.apply(fs, arguments)
       }
       const [offset, length] = entry
@@ -222,14 +219,12 @@ function shimFs(binary: NexeBinary, fs: any = require('fs')) {
       callback = typeof options === 'function' ? options : callback
 
       originalFsMethods.open(blobPath, 'r', function(err: Error, fd: number) {
-        console.log('readFile open callback: %o', { err, fd })
         if (err) return callback(err, null)
         originalFsMethods.read(fd, Buffer.alloc(length), 0, length, resourceOffset, function(
           error: Error,
           bytesRead: number,
           result: Buffer
         ) {
-          console.log('readFile read callback: %o', { error, bytesRead, result })
           if (error) {
             return originalFsMethods.close(fd, function() {
               callback(error, null)

--- a/src/fs/patch.ts
+++ b/src/fs/patch.ts
@@ -15,6 +15,12 @@ export interface NexeBinary {
 let originalFsMethods: any = null
 let lazyRestoreFs = () => {}
 
+// optional Win32 file namespace prefix followed by drive letter and colon
+const windowsFullPathRegex = /^(\\{2}\?\\)?([a-zA-Z]):/
+
+const upcaseDriveLetter = (s: string): string =>
+  s.replace(windowsFullPathRegex, (_match, ns, drive) => `${ns || ''}${drive.toUpperCase()}:`)
+
 function shimFs(binary: NexeBinary, fs: any = require('fs')) {
   if (originalFsMethods !== null) {
     return
@@ -28,7 +34,8 @@ function shimFs(binary: NexeBinary, fs: any = require('fs')) {
     isString = (x: any): x is string => typeof x === 'string' || x instanceof String,
     noop = () => {},
     path = require('path'),
-    baseDir = path.dirname(process.execPath)
+    winPath = (key: string): string => (isWin ? upcaseDriveLetter(key) : key),
+    baseDir = winPath(path.dirname(process.execPath))
 
   let log = (_: string) => true
   let loggedManifest = false
@@ -42,13 +49,6 @@ function shimFs(binary: NexeBinary, fs: any = require('fs')) {
       }
       return process.stderr.write('[nexe] - ' + text + '\n')
     }
-  }
-
-  const winPath = (key: string) => {
-    if (isWin && key.substr(1, 2) === ':\\') {
-      key = key[0].toUpperCase() + key.substr(1)
-    }
-    return key
   }
 
   const getKey = function getKey(filepath: string | Buffer | null): string {
@@ -308,8 +308,8 @@ function shimFs(binary: NexeBinary, fs: any = require('fs')) {
   const patches = (process as any).nexe.patches || {}
   delete (process as any).nexe
   patches.internalModuleReadFile = function(this: any, original: any, ...args: any[]) {
-    const [filepath] = args
     setupManifest()
+    const filepath = getKey(args[0])
     if (manifest[filepath]) {
       log('read     (hit)              ' + filepath)
       return nfs.readFileSync(filepath, 'utf-8')
@@ -320,7 +320,7 @@ function shimFs(binary: NexeBinary, fs: any = require('fs')) {
   patches.internalModuleReadJSON = patches.internalModuleReadFile
   patches.internalModuleStat = function(this: any, original: any, ...args: any[]) {
     setupManifest()
-    const [filepath] = args
+    const filepath = getKey(args[0])
     if (manifest[filepath]) {
       log('stat     (hit)              ' + filepath + '   ' + 0)
       return 0

--- a/src/fs/patch.ts
+++ b/src/fs/patch.ts
@@ -34,7 +34,7 @@ function shimFs(binary: NexeBinary, fs: any = require('fs')) {
     isString = (x: any): x is string => typeof x === 'string' || x instanceof String,
     noop = () => {},
     path = require('path'),
-    winPath = (key: string): string => (isWin ? upcaseDriveLetter(key) : key),
+    winPath: (key: string) => string = isWin ? upcaseDriveLetter : s => s,
     baseDir = winPath(path.dirname(process.execPath))
 
   let log = (_: string) => true
@@ -157,6 +157,7 @@ function shimFs(binary: NexeBinary, fs: any = require('fs')) {
     ;(manifest[notAFile] as any) = false
     ;(directories[notAFile] as any) = false
     setupManifest = noop
+    console.log('setupManifest: %o', manifest)
   }
 
   //naive patches intended to work for most use cases
@@ -209,8 +210,10 @@ function shimFs(binary: NexeBinary, fs: any = require('fs')) {
 
     readFile: function readFile(filepath: any, options: any, callback: any) {
       setupManifest()
+      console.log('readFile: %o', { filepath, options })
       const entry = manifest[getKey(filepath)]
       if (!entry) {
+        console.log('readFile calling original: %o with %o', originalFsMethods.readFile, arguments)
         return originalFsMethods.readFile.apply(fs, arguments)
       }
       const [offset, length] = entry
@@ -219,12 +222,14 @@ function shimFs(binary: NexeBinary, fs: any = require('fs')) {
       callback = typeof options === 'function' ? options : callback
 
       originalFsMethods.open(blobPath, 'r', function(err: Error, fd: number) {
+        console.log('readFile open callback: %o', { err, fd })
         if (err) return callback(err, null)
         originalFsMethods.read(fd, Buffer.alloc(length), 0, length, resourceOffset, function(
           error: Error,
           bytesRead: number,
           result: Buffer
         ) {
+          console.log('readFile read callback: %o', { error, bytesRead, result })
           if (error) {
             return originalFsMethods.close(fd, function() {
               callback(error, null)


### PR DESCRIPTION
Fixes https://github.com/nexe/nexe/issues/659

After packaging, running the following command on Windows
```
c:\MyDir\MyApp.exe
```

(note the lowercase drive letter)

caused the following exception:
```
internal/modules/cjs/loader.js:775
    throw err;
    ^

Error: Cannot find module 'c:\MyDir\dist\bundle.js'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:772:15)
    at Function.Module._load (internal/modules/cjs/loader.js:677:27)
    at Function.Module.runMain (internal/modules/cjs/loader.js:999:10)
    at internal/main/run_main_module.js:17:11 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
```

Summary of fixes:

- winPath was not upcasing drive letters of namespace-prefixed keys
- internalModuleReadFile and internalModuleStat were not normalizing keys before checking the manifest for existing entries