### PR TITLE
fix: resources not being included on Windows

### DIFF
--- a/src/steps/resource.ts
+++ b/src/steps/resource.ts
@@ -3,13 +3,18 @@ import * as globs from 'globby'
 import { NexeCompiler } from '../compiler'
 
 export default async function resource(compiler: NexeCompiler, next: () => Promise<any>) {
-  const { cwd } = compiler.options
-  if (!compiler.options.resources.length) {
+  const { cwd, resources } = compiler.options
+  if (!resources.length) {
     return next()
   }
   const step = compiler.log.step('Bundling Resources...')
   let count = 0
-  await each(globs(compiler.options.resources, { cwd }), async file => {
+
+  // workaround for https://github.com/sindresorhus/globby/issues/127
+  // and https://github.com/mrmlnc/fast-glob#pattern-syntax
+  const resourcesWithForwardSlashes = resources.map(r => r.replace(/\\/g, '/'))
+
+  await each(globs(resourcesWithForwardSlashes, { cwd }), async file => {
     if (await isDirectoryAsync(file)) {
       return
     }


### PR DESCRIPTION
Resources were not being picked up on Windows when specified with a backslash e.g, `mydir\myfile.ffs`

This is due to [this issue at globby](https://github.com/sindresorhus/globby/issues/127) which is in turn due to [this change at fast-glob](https://github.com/mrmlnc/fast-glob#pattern-syntax).

Workaround in this PR: converting all backslashes to forward-slashes.