### PR TITLE
Fix VFS: exists at /snapshot, does not block access to cwd

### DIFF
--- a/src/fs/patch.ts
+++ b/src/fs/patch.ts
@@ -35,7 +35,7 @@ function shimFs(binary: NexeBinary, fs: any = require('fs')) {
     noop = () => {},
     path = require('path'),
     winPath: (key: string) => string = isWin ? upcaseDriveLetter : s => s,
-    baseDir = winPath(path.dirname(process.execPath))
+    baseDir = winPath('/snapshot')
 
   let log = (_: string) => true
   let loggedManifest = false
@@ -52,6 +52,17 @@ function shimFs(binary: NexeBinary, fs: any = require('fs')) {
   }
 
   const getKey = function getKey(filepath: string | Buffer | null): string {
+    if (Buffer.isBuffer(filepath)) {
+      filepath = filepath.toString()
+    }
+    if (!isString(filepath)) {
+      return notAFile
+    }
+    let key = path.resolve(filepath)
+
+    return winPath(key)
+  }
+  const getKeyFromManifest = function getKey(filepath: string | Buffer | null): string {
     if (Buffer.isBuffer(filepath)) {
       filepath = filepath.toString()
     }
@@ -126,7 +137,7 @@ function shimFs(binary: NexeBinary, fs: any = require('fs')) {
   let setupManifest = () => {
     Object.keys(manifest).forEach(filepath => {
       const entry = manifest[filepath]
-      const absolutePath = getKey(filepath)
+      const absolutePath = getKeyFromManifest(filepath)
       const longPath = makeLong(absolutePath)
       const normalizedPath = winPath(path.normalize(filepath))
 

--- a/src/steps/shim.ts
+++ b/src/steps/shim.ts
@@ -27,9 +27,7 @@ export default async function(compiler: NexeCompiler, next: () => Promise<void>)
     wrap(`
       if (!process.send) {
         const path = require('path')
-        const entry = path.resolve(path.dirname(process.execPath),${JSON.stringify(
-          compiler.entrypoint
-        )})
+        const entry = path.resolve('/snapshot',${JSON.stringify(compiler.entrypoint)})
         process.argv.splice(1,0, entry)
       }
     `)


### PR DESCRIPTION
**What this PR does / why we need it**:

Allows accessing real filesystem in cwd from nexe binaries.  Current nexe behavior is confusing and maybe buggy, though I wasn't really able to tell what the intention was in some cases.

**Which issue(s) this PR fixes**:

Fixes #736

**Special notes for your reviewer**:

Changes `baseDir` to a hardcoded `/snapshot`.  Also fixes the behavior of `getKey`.  All manifest paths are relative to `baseDir` so it makes sense to prefix them with `baseDir` in `setupManifest`.  But when someone makes an `fs` calls with a relative path, we need to resolve that relative to `process.cwd`, not `baseDir`.