### PR TITLE
Handle multiline ProcessGlobalArgs change.

### DIFF
--- a/src/patches/disable-node-cli.ts
+++ b/src/patches/disable-node-cli.ts
@@ -7,7 +7,11 @@ export default async function disableNodeCli(compiler: NexeCompiler, next: () =>
   }
 
   if (semverGt(compiler.target.version, '11.6.0')) {
-    await compiler.replaceInFileAsync('src/node.cc', /(?<!int )ProcessGlobalArgs\(argv/g, '0;//$&')
+    await compiler.replaceInFileAsync(
+      'src/node.cc',
+      /(?<!int )ProcessGlobalArgs\(argv[^;]*;/gm,
+      '0;/*$&*/'
+    )
   } else if (semverGt(compiler.target.version, '10.9')) {
     await compiler.replaceInFileAsync('src/node.cc', /(?<!void )ProcessArgv\(argv/g, '//$&')
   } else if (semverGt(compiler.target.version, '9.999')) {


### PR DESCRIPTION
Fixes #739.

**What this PR does / why we need it**:

ProcessGlobalArgs was changed to be multiline. This can be seen with 12.16.1 now.

**Which issue(s) this PR fixes**:

Fixes #739.

**Special notes for your reviewer**:

I tried this manually with 12.16.1 and 11.7.0.

11.7.0: `const int exit_code = 0;/*ProcessGlobalArgs(argv, exec_argv, errors, false);*/`
12.16.1:
```
  const int exit_code = 0;/*ProcessGlobalArgs(argv,
                                          exec_argv,
                                          errors,
                                          kDisallowedInEnvironment);*/

```