### PR TITLE
Remove hasLoadedAnyUserCJSModule assertion to fix startup.

### DIFF
--- a/src/patches/third-party-main.ts
+++ b/src/patches/third-party-main.ts
@@ -71,6 +71,11 @@ export default async function main(compiler: NexeCompiler, next: () => Promise<v
       'initializePolicy();\n' + wrap('{{replace:lib/patches/boot-nexe.js}}')
     )
     await compiler.replaceInFileAsync(
+      bootFile,
+      'assert(!CJSLoader.hasLoadedAnyUserCJSModule)',
+      '/*assert(!CJSLoader.hasLoadedAnyUserCJSModule)*/'
+    )
+    await compiler.replaceInFileAsync(
       'src/node.cc',
       'MaybeLocal<Value> StartMainThreadExecution(Environment* env) {',
       'MaybeLocal<Value> StartMainThreadExecution(Environment* env) {\n' +


### PR DESCRIPTION
**What this PR does / why we need it**:

Removing an assertion added in [PR30349](https://github.com/nodejs/node/pull/30349).

**Which issue(s) this PR fixes**:

No issue created previously, but the error output with 12.16.1 is:

```
internal/assert.js:14
    throw new ERR_INTERNAL_ASSERTION(message);
    ^

Error [ERR_INTERNAL_ASSERTION]: This is caused by either a bug in Node.js or incorrect usage of Node.js internals.
Please open an issue with this stack trace at https://github.com/nodejs/node/issues

    at assert (internal/assert.js:14:11)
    at prepareMainThreadExecution (internal/bootstrap/pre_execution.js:129:3)
    at internal/main/run_main_module.js:7:1 {
  code: 'ERR_INTERNAL_ASSERTION'
}
```

**Special notes for your reviewer**:

_I'm not sure if there's a better way to deal with the upstream change, but this works for me..._

The "Also added an internal assertion `hasLoadedAnyUserCJSModule` for documentation purposes." statement in the PR made me think this _might_ be acceptable.

I only tested 12.16.1; but `replaceInFileAsync` doesn't explode if no match is found, right? (Hence thinking this should be safe for versions that don't contain this line.)