### PR TITLE
Add support for opendir, Dir and Dirent from 12.x.

### DIFF
--- a/src/fs/patch.ts
+++ b/src/fs/patch.ts
@@ -1,4 +1,5 @@
 import { Stats } from 'fs'
+import { join } from 'path'
 
 export interface NexeBinary {
   blobPath: string
@@ -101,6 +102,54 @@ function shimFs(binary: NexeBinary, fs: any = require('fs')) {
     return stat
   }
 
+  const createDirent = function(parentKey: string, childName: string) {
+    const filepath = join(parentKey, childName)
+    return new fs.Dirent(
+      childName,
+      filepath in directories ? fs.constants.UV_DIRENT_DIR : fs.constants.UV_DIRENT_FILE
+    )
+  }
+  const createDir = function(filepath: string | Buffer, options: string, _entries: any) {
+    const Dir = originalFsMethods.Dir
+    let entries = _entries.map((x: any) => x)
+    let closed = false
+    Object.assign(Dir.prototype, {
+      read: function read(callback: any) {
+        if (closed) {
+          const e = new Error('Directory handle was closed')
+          Object.assign(e, { code: 'ERR_DIR_CLOSED' })
+          throw e
+        }
+        callback(null, entries.shift())
+      },
+      readSync: function readSync(options: any) {
+        if (closed) {
+          const e = new Error('Directory handle was closed')
+          Object.assign(e, { code: 'ERR_DIR_CLOSED' })
+          throw e
+        }
+        return entries.shift()
+      },
+      close: function close(callback: any) {
+        process.nextTick(() => {
+          closed = true
+          entries = null
+          callback(null)
+        })
+      },
+      closeSync: function closeSync() {
+        closed = true
+      },
+      async *entries() {
+        while (entries.length > 0) {
+          yield entries.shift()
+        }
+      }
+    })
+    Dir.prototype[Symbol.asyncIterator] = Dir.prototype.entries
+    return new Dir({}, filepath, options)
+  }
+
   const ownStat = function (filepath: any, options: any) {
     setupManifest()
     const key = getKey(filepath)
@@ -187,24 +236,66 @@ function shimFs(binary: NexeBinary, fs: any = require('fs')) {
     },
     readdir: function readdir(filepath: string | Buffer, options: any, callback: any) {
       setupManifest()
-      const dir = directories[getKey(filepath)]
+      const key = getKey(filepath)
+      const dir = directories[key]
       if (dir) {
         if ('function' === typeof options) {
           callback = options
           options = { encoding: 'utf8' }
         }
-        process.nextTick(() => callback(null, Object.keys(dir)))
+        process.nextTick(() => {
+          debugger
+          let result = Object.keys(dir)
+          if (options.withFileTypes) {
+            result = result.map(child => createDirent(key, child))
+          }
+          callback(null, result)
+        })
       } else {
         return originalFsMethods.readdir.apply(fs, arguments)
       }
     },
     readdirSync: function readdirSync(filepath: string | Buffer, options: any) {
       setupManifest()
-      const dir = directories[getKey(filepath)]
+      const key = getKey(filepath)
+      const dir = directories[key]
       if (dir) {
-        return Object.keys(dir)
+        let result = Object.keys(dir)
+        if (options.withFileTypes) {
+          result = result.map(child => createDirent(key, child))
+        }
+        return result
       }
       return originalFsMethods.readdirSync.apply(fs, arguments)
+    },
+
+    opendir: function opendir(filepath: string | Buffer, options: any, callback: any) {
+      setupManifest()
+      const key = getKey(filepath)
+      const dir = directories[key]
+      if (dir) {
+        if ('function' === typeof options) {
+          callback = options
+          options = { encoding: 'utf8' }
+        }
+        process.nextTick(() => {
+          const files: any = Object.keys(dir).map(child => createDirent(key, child))
+          callback(null, createDir(filepath, options, files))
+        })
+      } else {
+        return originalFsMethods.opendir.apply(fs, arguments)
+      }
+    },
+    opendirSync: function opendir(filepath: string | Buffer, options: any) {
+      setupManifest()
+      const key = getKey(filepath)
+      const dir = directories[key]
+      if (dir) {
+        const files: any = Object.keys(dir).map(child => createDirent(key, child))
+        return createDir(filepath, options, files)
+      } else {
+        return originalFsMethods.opendir.apply(fs, arguments)
+      }
     },
 
     readFile: function readFile(filepath: any, options: any, callback: any) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Add support for the Dirent/Dir stuff that was added during the 12.x release.
We hit this with the `withFileTypes` flag on readdir, but also added the opendir support too.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
No issue created.

**Special notes for your reviewer**:

I've just been testing this locally (with `globby` which is where we hit this issue, also a quick test script for opendir/opendirSync and visually comparing with native).

I kinda wonder whether a test suite for the fs patching would be good and practical? Just a pondering, but I am nervous about whether this is 100% right.

My typescript is super weak, so apologies for anything bad in there :-s 