### PR TITLE
Adds alternate pre-built Nexe binary remote option (--remote)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ compile({
     - default: true
  - #### `build: boolean`
     - Build node from source, passing this flag tells nexe to download and build from source. Subsequently using this flag will cause nexe to use the previously built binary. To rebuild, first add [`--clean`](#clean-boolean)
- - #### `asset: string`
-    - Provide a pre-built nexe binary asset, this can either be an http or https URL or a file path.
+ - #### `remote: string`
+    - Provide a custom remote location for fetching pre-built nexe binaries from. This can either be an HTTP or HTTPS URL or a file path.
     - default: `null`
  - #### `python: string`
     - On Linux this is the path pointing to your python2 executable

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -111,8 +111,10 @@ export class NexeCompiler {
     if (options.asset && options.asset.startsWith('http')) {
       this.remoteAsset = options.asset
     } else {
-      this.remoteAsset =
-        'https://github.com/nexe/nexe/releases/download/v3.0.0/' + this.target.toString()
+      if (!options.remote.startsWith('http')) {
+        throw new NexeError(`Invalid remote URL (must be HTTP/HTTPS): ${options.remote}`)
+      }
+      this.remoteAsset = options.remote + this.target.toString()
     }
     this.src = join(this.options.temp, this.target.version)
     this.configureScript = configure + (semverGt(this.target.version, '10.10.0') ? '.py' : '')

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -108,14 +108,18 @@ export class NexeCompiler {
     //SOMEDAY iterate over multiple targets with `--outDir`
     this.targets = options.targets as NexeTarget[]
     this.target = this.targets[0]
-    if (options.asset && options.asset.startsWith('http')) {
-      this.remoteAsset = options.asset
-    } else {
-      if (!options.remote.startsWith('http')) {
-        throw new NexeError(`Invalid remote URL (must be HTTP/HTTPS): ${options.remote}`)
-      }
-      this.remoteAsset = options.remote + this.target.toString()
+    if (
+      !(
+        options.remote.startsWith('http://') ||
+        options.remote.startsWith('https://') ||
+        options.remote.startsWith('file://')
+      )
+    ) {
+      throw new NexeError(
+        `Invalid remote URI scheme (must be http, https, or file): ${options.remote}`
+      )
     }
+    this.remoteAsset = options.remote + this.target.toString()
     this.src = join(this.options.temp, this.target.version)
     this.configureScript = configure + (semverGt(this.target.version, '10.10.0') ? '.py' : '')
     this.nodeSrcBinPath = isWindows
@@ -200,9 +204,6 @@ export class NexeCompiler {
   }
 
   public getNodeExecutableLocation(target?: NexeTarget) {
-    if (this.options.asset && !this.options.asset.startsWith('http')) {
-      return resolve(this.options.cwd, this.options.asset)
-    }
     if (target) {
       return join(this.options.temp, target.toString())
     }

--- a/src/options.ts
+++ b/src/options.ts
@@ -39,6 +39,7 @@ export interface NexeOptions {
   native: any
   mangle: boolean
   ghToken: string
+  remote: string
   sourceUrl?: string
   enableStdIn?: boolean
   python?: string
@@ -71,6 +72,7 @@ const defaults = {
   bundle: true,
   patches: [],
   plugins: [],
+  remote: 'https://github.com/nexe/nexe/releases/download/v3.0.0/',
 }
 const alias = {
   i: 'input',
@@ -87,6 +89,7 @@ const alias = {
   m: 'make',
   h: 'help',
   l: 'loglevel',
+  e: 'remote',
   'fake-argv': 'fakeArgv',
   'gh-token': 'ghToken',
 }
@@ -103,6 +106,7 @@ ${c.bold('nexe <entry-file> [options]')}
   -r   --resource                   -- *embed files (glob) within the binary
   -a   --asset                      -- alternate asset path, file or url pointing to a base (nexe) binary
        --plugin                     -- extend nexe runtime behavior
+  -e   --remote                     -- third-party remote location (URL) to download pre-built releases from
 
    ${c.underline.bold('Building from source:')}
 
@@ -248,6 +252,10 @@ function normalizeOptions(input?: Partial<NexeOptions>): NexeOptions {
   options.make = flatten(isWindows ? options.vcBuild : options.make)
   options.configure = flatten(options.configure)
   options.resources = flatten(opts.resource, options.resources)
+
+  if (!options.remote.endsWith('/')) {
+    options.remote += '/'
+  }
 
   options.downloadOptions = options.downloadOptions || {}
   options.downloadOptions.headers = options.downloadOptions.headers || {}

--- a/src/options.ts
+++ b/src/options.ts
@@ -112,7 +112,7 @@ ${c.bold('nexe <entry-file> [options]')}
   -c   --configure                  -- *arguments to the configure step
   -m   --make                       -- *arguments to the make/build step
        --patch                      -- module with middleware default export for adding a build patch
-       --no-mangle                  -- used when generating base binaries, or when patching _third_party_main manually.
+       --no-mangle                  -- used when generating base binaries, or when patching _third_party_main manually
        --snapshot                   -- path to a warmup snapshot
        --ico                        -- file name for alternate icon file (windows)
        --rc-*                       -- populate rc file options (windows)

--- a/src/options.ts
+++ b/src/options.ts
@@ -21,7 +21,7 @@ export interface NexeOptions {
   output: string
   targets: (string | NexeTarget)[]
   name: string
-  asset: string
+  remote: string
   cwd: string
   fs: boolean | string[]
   flags: string[]
@@ -39,7 +39,6 @@ export interface NexeOptions {
   native: any
   mangle: boolean
   ghToken: string
-  remote: string
   sourceUrl?: string
   enableStdIn?: boolean
   python?: string
@@ -82,14 +81,12 @@ const alias = {
   b: 'build',
   n: 'name',
   r: 'resource',
-  a: 'asset',
   p: 'python',
   f: 'flag',
   c: 'configure',
   m: 'make',
   h: 'help',
   l: 'loglevel',
-  e: 'remote',
   'fake-argv': 'fakeArgv',
   'gh-token': 'ghToken',
 }
@@ -104,9 +101,8 @@ ${c.bold('nexe <entry-file> [options]')}
   -t   --target                     -- node version description
   -n   --name                       -- main app module name
   -r   --resource                   -- *embed files (glob) within the binary
-  -a   --asset                      -- alternate asset path, file or url pointing to a base (nexe) binary
+       --remote                     -- alternate location (URL) to download pre-built base (nexe) binaries from
        --plugin                     -- extend nexe runtime behavior
-  -e   --remote                     -- third-party remote location (URL) to download pre-built releases from
 
    ${c.underline.bold('Building from source:')}
 

--- a/test/options.spec.ts
+++ b/test/options.spec.ts
@@ -39,6 +39,26 @@ describe('options', () => {
       expect(options.output).to.equal(path.resolve(cwd, `abc${ext}`))
     })
   })
+
+  describe('remote', () => {
+    it('should use default remote', () => {
+      const options = normalizeOptions({})
+      expect(options.remote).to.equal('https://github.com/nexe/nexe/releases/download/v3.0.0/')
+    })
+    it('should append trailing slash to third-party remote if necessary', () => {
+      const options = normalizeOptions({
+        remote: 'https://sitejs.org/nexe'
+      })
+      expect(options.remote).to.equal('https://sitejs.org/nexe/')
+    })
+    it('should not append trailing slash to third-party remote that already has one', () => {
+      const options = normalizeOptions({
+        remote: 'https://sitejs.org/nexe/'
+      })
+      expect(options.remote).to.equal('https://sitejs.org/nexe/')
+    })
+  })
+
   describe('output', () => {
     it('should work', () => {
       const options = normalizeOptions({


### PR DESCRIPTION
## What this PR does / why we need it

  - Removes `--asset` option, which was not working as designed.
  - Adds `--remote` option, which covers the same use case in a slightly more generic manner.

## Which issue(s) this PR fixes

Fixes #760

## Special notes for your reviewer

Thanks for your help in narrowing this down, @calebboyd, appreciate it.

I’ve tried to adhere to the project conventions as much as possible but please do let me know if you want any changes.