### PR TITLE
Move nexe boot to support 12.18.0.

### DIFF
--- a/src/patches/third-party-main.ts
+++ b/src/patches/third-party-main.ts
@@ -65,11 +65,19 @@ export default async function main(compiler: NexeCompiler, next: () => Promise<v
   file.contents = fileLines.join('\n')
 
   if (semverGt(version, '11.99')) {
-    await compiler.replaceInFileAsync(
-      bootFile,
-      'initializePolicy();',
-      'initializePolicy();\n' + wrap('{{replace:lib/patches/boot-nexe.js}}')
-    )
+    if (semverGt(version, '12.17.99')) {
+      await compiler.replaceInFileAsync(
+        bootFile,
+        'initializeFrozenIntrinsics();',
+        'initializeFrozenIntrinsics();\n' + wrap('{{replace:lib/patches/boot-nexe.js}}')
+      )
+    } else {
+      await compiler.replaceInFileAsync(
+        bootFile,
+        'initializePolicy();',
+        'initializePolicy();\n' + wrap('{{replace:lib/patches/boot-nexe.js}}')
+      )
+    }
     await compiler.replaceInFileAsync(
       bootFile,
       'assert(!CJSLoader.hasLoadedAnyUserCJSModule)',


### PR DESCRIPTION
**What this PR does / why we need it**:

Moves the location where nexe boot is included for node 12.18. 

**Which issue(s) this PR fixes**:

No issue created, but the error was:

```
internal/modules/cjs/loader.js:1078
  callbackMap.set(compiled.cacheKey, {
              ^

TypeError: Cannot read property 'set' of undefined
    at wrapSafe (internal/modules/cjs/loader.js:1078:15)
    at Module._compile (internal/modules/cjs/loader.js:1102:27)
    at internal/bootstrap/pre_execution.js:118:36
    at prepareMainThreadExecution (internal/bootstrap/pre_execution.js:119:3)
    at internal/main/run_main_module.js:7:1
```

As `callbackMap` is setup later in prepareMainThreadExecution.

**Special notes for your reviewer**:

Just tested manually against 12.18 - due to the logic this shouldn't affect any other version adversely.