### PR TITLE
Internal module read json changes

### DIFF
--- a/src/fs/patch.ts
+++ b/src/fs/patch.ts
@@ -317,8 +317,9 @@ function shimFs(binary: NexeBinary, fs: any = require('fs')) {
     log('read          (miss)       ' + filepath)
     return original.call(this, ...args)
   }
+  let returningArray: boolean
   patches.internalModuleReadJSON = function (this: any, original: any, ...args: any[]) {
-    const returningArray = Array.isArray(original.call(this, ''))
+    if (returningArray == null) returningArray = Array.isArray(original.call(this, ''))
     const res = patches.internalModuleReadFile.call(this, original, ...args)
     return returningArray && !Array.isArray(res)
       ? [res, /"(name|main|type|exports)"/.test(res)]

--- a/src/fs/patch.ts
+++ b/src/fs/patch.ts
@@ -322,7 +322,7 @@ function shimFs(binary: NexeBinary, fs: any = require('fs')) {
     if (returningArray == null) returningArray = Array.isArray(original.call(this, ''))
     const res = patches.internalModuleReadFile.call(this, original, ...args)
     return returningArray && !Array.isArray(res)
-      ? [res, /"(name|main|type|exports)"/.test(res)]
+      ? [res, /"(main|name|type|exports|imports)"/.test(res)]
       : res
   }
   patches.internalModuleStat = function (this: any, original: any, ...args: any[]) {

--- a/src/fs/patch.ts
+++ b/src/fs/patch.ts
@@ -317,7 +317,11 @@ function shimFs(binary: NexeBinary, fs: any = require('fs')) {
     log('read          (miss)       ' + filepath)
     return original.call(this, ...args)
   }
-  patches.internalModuleReadJSON = patches.internalModuleReadFile
+  patches.internalModuleReadJSON = function (this: any, original: any, ...args: any[]) {
+    const returningArray = Array.isArray(original.call(this, ''))
+    const res = patches.internalModuleReadFile.call(this, original, ...args)
+    return returningArray && !Array.isArray(res) ? [res, true] : res
+  }
   patches.internalModuleStat = function (this: any, original: any, ...args: any[]) {
     setupManifest()
     const filepath = getKey(args[0])

--- a/src/fs/patch.ts
+++ b/src/fs/patch.ts
@@ -320,7 +320,9 @@ function shimFs(binary: NexeBinary, fs: any = require('fs')) {
   patches.internalModuleReadJSON = function (this: any, original: any, ...args: any[]) {
     const returningArray = Array.isArray(original.call(this, ''))
     const res = patches.internalModuleReadFile.call(this, original, ...args)
-    return returningArray && !Array.isArray(res) ? [res, true] : res
+    return returningArray && !Array.isArray(res)
+      ? [res, /"(name|main|type|exports)"/.test(res)]
+      : res
   }
   patches.internalModuleStat = function (this: any, original: any, ...args: any[]) {
     setupManifest()


### PR DESCRIPTION
**What this PR does / why we need it**:

With 12.18.3 (and probably somewhere on master) the return value of internalModuleReadJSON changed to being an array.

**Which issue(s) this PR fixes**:

No issue raised, the breakage was with package.json loading.

**Special notes for your reviewer**:

Manually tested against 12.18.3 and 12.18.2 (to test the new and old functionality).

The regex test is to match the check at: https://github.com/nodejs/node/blob/master/src/node_file.cc#L958