### PR TITLE
Add support fs.realpath(Sync).native.

### DIFF
--- a/src/fs/patch.ts
+++ b/src/fs/patch.ts
@@ -399,6 +399,25 @@ function shimFs(binary: NexeBinary, fs: any = require('fs')) {
     }
   }
 
+  if (typeof fs.realpath.native === 'function') {
+    nfs.realpath.native = function realpathNative(filepath: any, options: any, cb: any): void {
+      setupManifest()
+      const key = getKey(filepath)
+      if (isString(filepath) && (manifest[filepath] || manifest[key])) {
+        return process.nextTick(() => cb(null, filepath))
+      }
+      return originalFsMethods.realpath.native.call(fs, filepath, options, cb)
+    }
+    nfs.realpathSync.native = function realpathSyncNative(filepath: any, options: any) {
+      setupManifest()
+      const key = getKey(filepath)
+      if (manifest[key]) {
+        return filepath
+      }
+      return originalFsMethods.realpathSync.native.call(fs, filepath, options)
+    }
+  }
+
   Object.assign(fs, nfs)
 
   lazyRestoreFs = () => {


### PR DESCRIPTION
**What this PR does / why we need it**:

Improve compatibility with the Node fs api,

Adds support for fs-extra v10.

As of https://github.com/jprichardson/node-fs-extra/commit/fb6c0ca16baec6a3f5138685e72cf3659c493017
they no longer conditionally look for these functions.