### PR TITLE
Document the asset option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,10 @@ compile({
  - #### `build: boolean`
     - Build node from source, passing this flag tells nexe to download and build from source. Subsequently using this flag will cause nexe to use the previously built binary. To rebuild, first add [`--clean`](#clean-boolean)
  - #### `remote: string`
-    - Provide a custom remote location for fetching pre-built nexe binaries from. This can either be an HTTP or HTTPS URL or a file path.
+    - Provide a custom remote location for fetching pre-built nexe binaries from. This can either be an HTTP or HTTPS URL.
     - default: `null`
+ - #### `asset: string`
+    - Provide a pre-built nexe binary asset, this is a file path is resolved relative to cwd.
  - #### `python: string`
     - On Linux this is the path pointing to your python2 executable
     - On Windows this is the directory where `python` can be accessed

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -111,9 +111,7 @@ export class NexeCompiler {
     this.targets = options.targets as NexeTarget[]
     this.target = this.targets[0]
     if (!/https?\:\/\//.test(options.remote)) {
-      throw new NexeError(
-        `Invalid remote URI scheme (must be http, https, or file): ${options.remote}`
-      )
+      throw new NexeError(`Invalid remote URI scheme (must be http or https): ${options.remote}`)
     }
     this.remoteAsset = options.remote + this.target.toString()
     this.src = join(this.options.temp, this.target.version)


### PR DESCRIPTION
**What this PR does / why we need it**:

The asset option was added in 9f22309949bf8207cb9e4566f917d5bdd0324a01 but not added to the README.

Also the error message for remote still referenced "file" even though it was invalid.

Just if of use :-) (I was trawling around and noticed the asset option which is useful for some caching for us.)