### PR TITLE
Change python2 to python3 in options file

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -109,7 +109,7 @@ ${c.bold('nexe <entry-file> [options]')}
    ${c.underline.bold('Building from source:')}
 
   -b   --build                      -- build from source
-  -p   --python                     -- python2 (as python) executable path
+  -p   --python                     -- python3 (as python) executable path
   -f   --flag                       -- *v8 flags to include during compilation
   -c   --configure                  -- *arguments to the configure step
   -m   --make                       -- *arguments to the make/build step


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes the options' python description to point to a python3 path instead of python2

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes (none that I'm aware of?)

**Special notes for your reviewer**:
Heyo o/

I found when building my project and compiling node from source (since nexe didn't have the source on its repo?) that it didn't like the python syntax. Something *somewhere* along the line was trying to use the python [f string syntax](https://realpython.com/python-f-strings/), **which is not available in python 2.** I'm not sure if that's something nexe was doing or something in the node build process, but wherever that python call was, changing the python path (via `nexe --python /usr/bin/python3`) fixed it, and it seems to be compiling fine now.

That's it. That's literally all this PR is. Just a single character change.