### PR TITLE
fix: use correct ignore ssl env var

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -261,7 +261,7 @@ function normalizeOptions(input?: Partial<NexeOptions>): NexeOptions {
   options.downloadOptions.agent = process.env.HTTPS_PROXY
     ? caw(process.env.HTTPS_PROXY, { protocol: 'https' })
     : options.downloadOptions.agent || require('https').globalAgent
-  options.downloadOptions.rejectUnauthorized = process.env.HTTPS_PROXY ? false : true
+  options.downloadOptions.rejectUnauthorized = process.env.NODE_TLS_REJECT_UNAUTHORIZED ? false : true
 
   options.rc = options.rc || extractCliMap(/^rc-.*/, options)
   options.output =


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes an issue where SSL errors were being ignored by looking at the env var `HTTPS_PROXY` rather than `NODE_TLS_REJECT_UNAUTHORIZED`. The reason for this is that setting a proxy is not always related to wanting to ignore certificate errors IE in the place there is a transparent proxy in place. The correct way to use a proxy and whether to ignore SSL errors as seperate settings.

**Which issue(s) this PR fixes**:
Fixes https://github.com/nexe/nexe/issues/929

**Special notes for your reviewer**:
This will cause an issue for anybody who is using a non transparent proxy (via HTTPS_PROXY env var) and invalid certificates would also need to set `NODE_TLS_REJECT_UNAUTHORIZED=1` - however chances are they're already doing this for npm and other node stuff. 