### PR TITLE
enable static specification of node-options

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -26,6 +26,7 @@ export interface NexeOptions {
   cwd: string
   fs: boolean | string[]
   flags: string[]
+  nodeOptions: string[]
   configure: string[]
   vcBuild: string[]
   make: string[]
@@ -60,6 +61,7 @@ export interface NexeOptions {
 
 const defaults = {
   flags: [],
+  nodeOptions: [],
   cwd: process.cwd(),
   fs: true,
   configure: [],
@@ -85,6 +87,7 @@ const alias = {
   r: 'resource',
   p: 'python',
   f: 'flag',
+  e: 'nodeOption',
   c: 'configure',
   m: 'make',
   h: 'help',
@@ -111,6 +114,7 @@ ${c.bold('nexe <entry-file> [options]')}
   -b   --build                      -- build from source
   -p   --python                     -- python3 (as python) executable path
   -f   --flag                       -- *v8 flags to include during compilation
+  -e   --node-option                -- node option
   -c   --configure                  -- *arguments to the configure step
   -m   --make                       -- *arguments to the make/build step
        --patch                      -- module with middleware default export for adding a build patch
@@ -242,6 +246,7 @@ function normalizeOptions(input?: Partial<NexeOptions>): NexeOptions {
   options.name = extractName(options)
   options.loglevel = extractLogLevel(options)
   options.flags = flatten(opts.flag, options.flags)
+  options.nodeOptions = flatten(opts['node-option'], options.nodeOptions)
   options.targets = flatten(opts.target, options.targets).map(getTarget)
   if (!options.targets.length) {
     options.targets.push(getTarget())

--- a/src/patches/index.ts
+++ b/src/patches/index.ts
@@ -6,7 +6,8 @@ import flags from './flags'
 import ico from './ico'
 import rc from './node-rc'
 import snapshot from './snapshot'
+import options from './options'
 
-const patches = [gyp, bootNexe, buildFixes, cli, flags, ico, rc, snapshot]
+const patches = [gyp, bootNexe, buildFixes, cli, flags, ico, rc, snapshot, options]
 
 export default patches

--- a/src/patches/options.ts
+++ b/src/patches/options.ts
@@ -1,0 +1,25 @@
+import { NexeCompiler } from '../compiler';
+
+export default async function options(compiler: NexeCompiler, next: () => Promise<void>) {
+  const nodeOptions = compiler.options.nodeOptions;
+  if (!nodeOptions.length) {
+    return next();
+  }
+
+  const find = '#if !defined(NODE_WITHOUT_NODE_OPTIONS)';
+  const code = `do {
+    std::string node_options = ${JSON.stringify(nodeOptions.join(' '))};
+    std::vector<std::string> env_argv = ParseNodeOptionsEnvVar(node_options, errors);
+    if (!errors->empty()) return 9;
+    env_argv.insert(env_argv.begin(), argv->at(0));
+    const int exit_code = ProcessGlobalArgs(&env_argv, nullptr, errors, kAllowedInEnvironment);
+    if (exit_code != 0) return exit_code;
+  } while(0);
+  
+  ${find}
+  `;
+
+  await compiler.replaceInFileAsync('src/node.cc', find, code);
+
+  return next();
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This is intended to implement passing compile-time `NODE_OPTIONS` to node. I am using this to pass `--experimental-vm-modules --no-warnings` to a project of mine.

**Which issue(s) this PR fixes**:

Fixes #616

**Special notes for your reviewer**:

At this point I just want to know whether this is the right approach in your eyes. If it is, I'll go through and clean this up and make sure it works against a set of node-versions of your choice. Right now I did this against node ***17.3.0*** and haven't validated against any other version.
