### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -26,7 +26,7 @@ function falseOnEnoent(e: any) {
 }
 
 function padRight(str: string, l: number) {
-  return (str + ' '.repeat(l)).substr(0, l)
+  return (str + ' '.repeat(l)).slice(0, l)
 }
 
 const bound: MethodDecorator = function bound<T>(


### PR DESCRIPTION
**What this PR does / why we need it**:

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**: