### PR TITLE
fix: missed space in downloading log line

### DIFF
--- a/src/steps/download.ts
+++ b/src/steps/download.ts
@@ -58,7 +58,7 @@ export default async function downloadNode(compiler: NexeCompiler, next: () => P
     { sourceUrl, downloadOptions, build } = compiler.options,
     url = sourceUrl || `https://nodejs.org/dist/v${version}/node-v${version}.tar.gz`,
     step = log.step(
-      `Downloading ${build ? '' : 'pre-built'} Node.js ${build ? `source from: ${url}` : ''}`
+      `Downloading ${build ? '' : 'pre-built '}Node.js${build ? ` source from: ${url}` : ''}`
     ),
     exeLocation = compiler.getNodeExecutableLocation(build ? undefined : target),
     downloadExists = await pathExistsAsync(build ? src : exeLocation)

--- a/src/steps/download.ts
+++ b/src/steps/download.ts
@@ -58,7 +58,7 @@ export default async function downloadNode(compiler: NexeCompiler, next: () => P
     { sourceUrl, downloadOptions, build } = compiler.options,
     url = sourceUrl || `https://nodejs.org/dist/v${version}/node-v${version}.tar.gz`,
     step = log.step(
-      `Downloading ${build ? '' : 'pre-built '}Node.js${build ? `source from: ${url}` : ''}`
+      `Downloading ${build ? '' : 'pre-built'} Node.js ${build ? `source from: ${url}` : ''}`
     ),
     exeLocation = compiler.getNodeExecutableLocation(build ? undefined : target),
     downloadExists = await pathExistsAsync(build ? src : exeLocation)


### PR DESCRIPTION
**What this PR does / why we need it**:
Just makes downloading nodejs output look better

before:
![image](https://github.com/nexe/nexe/assets/67136658/9b05a8dc-f5fa-4458-a81e-529be4ee8c84)

After:
![image](https://github.com/nexe/nexe/assets/67136658/1f56ffd8-82f9-4540-9922-22966c16ed69)

**Special notes for your reviewer**:
This is not required