### PR TITLE
Handle new ProcessGlobalArgsInternal function in node >19

### DIFF
--- a/src/patches/disable-node-cli.ts
+++ b/src/patches/disable-node-cli.ts
@@ -6,7 +6,14 @@ export default async function disableNodeCli(compiler: NexeCompiler, next: () =>
     return next()
   }
 
-  if (semverGt(compiler.target.version, '11.6.0')) {
+
+  if (semverGt(compiler.target.version, '18.11.99')) {
+    await compiler.replaceInFileAsync(
+      'src/node.cc',
+      /(?<!static ExitCode )ProcessGlobalArgsInternal\(argv[^;]*;/gm,
+      'ExitCode::kNoFailure;/*$&*/'
+    )
+  } else if (semverGt(compiler.target.version, '11.6.0')) {
     await compiler.replaceInFileAsync(
       'src/node.cc',
       /(?<!int )ProcessGlobalArgs\(argv[^;]*;/gm,

--- a/src/patches/disable-node-cli.ts
+++ b/src/patches/disable-node-cli.ts
@@ -7,7 +7,7 @@ export default async function disableNodeCli(compiler: NexeCompiler, next: () =>
   }
 
 
-  if (semverGt(compiler.target.version, '18.19.99')) {
+  if (semverGt(compiler.target.version, '18.99')) {
     await compiler.replaceInFileAsync(
       'src/node.cc',
       /(?<!static ExitCode )ProcessGlobalArgsInternal\(argv[^;]*;/gm,

--- a/src/patches/disable-node-cli.ts
+++ b/src/patches/disable-node-cli.ts
@@ -7,7 +7,7 @@ export default async function disableNodeCli(compiler: NexeCompiler, next: () =>
   }
 
 
-  if (semverGt(compiler.target.version, '18.11.99')) {
+  if (semverGt(compiler.target.version, '18.19.99')) {
     await compiler.replaceInFileAsync(
       'src/node.cc',
       /(?<!static ExitCode )ProcessGlobalArgsInternal\(argv[^;]*;/gm,


### PR DESCRIPTION
**What this PR does / why we need it**:

As of https://github.com/nodejs/node/pull/44746, the function that formerly performed global variable processing changed from `ProcessGlobalArgs` to `ProcessGlobalArgsInternal` with a different return type. This is causing the error seen in https://github.com/nexe/nexe/issues/1084 and https://github.com/nexe/nexe/issues/1082.

**Which issue(s) this PR fixes**:

Fixes https://github.com/nexe/nexe/issues/1082
Fixes https://github.com/nexe/nexe/issues/1084

**Special notes for your reviewer**: