### PR TITLE
Fix `Error: spawn EINVAL` on Windows.

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -209,6 +209,7 @@ export class NexeCompiler {
       spawn(command, args, {
         cwd: this.src,
         env: this.env,
+        shell: true,
         stdio: this.log.verbose ? 'inherit' : 'ignore',
       })
         .once('error', (e: Error) => {


### PR DESCRIPTION
**What this PR does / why we need it**:

After `21.7.3`, `20.12.2` and `18.20.2`, the `Error: spawn EINVAL` started occurring, so I have fixed it.

**Which issue(s) this PR fixes**:

Fixes #1091 

**Special notes for your reviewer**:

There are none.