### PR TITLE
Fix file lookup when the nexe binary is in another directory.

### DIFF
--- a/src/fs/SnapshotZipFS.ts
+++ b/src/fs/SnapshotZipFS.ts
@@ -130,6 +130,21 @@ export class SnapshotZipFS extends BasePortableFakeFS {
             )
           )
         ),
+        ppath.resolve(
+          snapshotPP,
+          npath.toPortablePath(
+            npath.relative(npath.fromPortablePath(process.cwd()), npath.fromPortablePath(p))
+          )
+        ),
+        ppath.resolve(
+          snapshotPP,
+          npath.toPortablePath(
+            npath.relative(
+              toNamespacedPath(npath.fromPortablePath(process.cwd())),
+              toNamespacedPath(npath.fromPortablePath(p))
+            )
+          )
+        ),
       ])
     )
     for (const path of pathsToTry) {

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -6,18 +6,32 @@ const cp = require('child_process')
 
 async function runTests() {
   const tempdir = await mkdtemp(path.join(os.tmpdir(), 'nexe-integration-tests-'))
+  const secondTempdir = await mkdtemp(path.join(os.tmpdir(), 'nexe-integration-tests-without-executable-'))
   const executable = path.join(tempdir, path.basename(process.argv[0]))
   await copyFile(process.argv[0], executable)
-  process.on('beforeExit', () => rimraf.sync(tempdir))
-  cp.spawn(executable,
-    [
-    path.join(tempdir, 'node_modules/mocha/bin/mocha.js'),
-      path.join(tempdir, 'test/integration/tests.integration-spec.js')
-    ],
-    { stdio: ['inherit', 'inherit', 'inherit', 'ipc'], cwd: tempdir }
-  ).on('exit', (code) => {
-    process.exitCode = code
+  process.on('beforeExit', () => {
+    rimraf.sync(tempdir)
+    rimraf.sync(secondTempdir)
   })
+  console.error('Running integration tests with the binary in the current working directory.')
+  spawnExecutable(tempdir, () => {
+    console.error('Running integration tests with the binary in another directory.')
+    spawnExecutable(secondTempdir)
+  })
+
+  function spawnExecutable(cwd, cb) {
+    cp.spawn(executable,
+      [
+      path.join(tempdir, 'node_modules/mocha/bin/mocha.js'),
+        path.join(tempdir, 'test/integration/tests.integration-spec.js')
+      ],
+      { stdio: ['inherit', 'inherit', 'inherit', 'ipc'], cwd }
+    ).on('exit', (code) => {
+      process.exitCode = process.exitCode || code
+
+      if(cb) cb()
+    })
+  }
 }
 
 runTests()


### PR DESCRIPTION
Hi @calebboyd,

This is a fix for a compatibility bug in the 5.x branch. In 4.x a file path relative to the current working directory would always be looked up in the nexe binary, and I missed this in the swap to the `/snapshot` path handing in 5.x.

This fixes that, and makes the integration tests run this case too.

I'm moving a bigger app to nexe 5, and this is the main/only blocker I've hit (so far) - so keen to get this landed if possible :-)

Thanks :-)