### PR TITLE
fix(node22): handle new arg order

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nexe",
   "description": "Create a single executable out of your Node.js application",
   "license": "MIT",
-  "version": "5.0.0-beta.3",
+  "version": "5.0.0-beta.4",
   "contributors": [
     "Craig Condon <craig.j.condon@gmail.com> (http://crcn.io)",
     "Jared Allard <jaredallard@outlook.com>",

--- a/src/fs/patch.ts
+++ b/src/fs/patch.ts
@@ -88,14 +88,19 @@ function shimFs(binary: NexeHeader, fs: typeof import('fs') = require('fs')) {
       : res
   }
   patches.internalModuleStat = function (this: any, original: any, ...args: any[]) {
-    log(`internalModuleStat ${args[0]}`)
+    let statPath = args[0]
+    //in node 22, the path arg moved to arg[1]
+    if (typeof args[0] !== 'string') statPath = args[1]
+    let result = 0
     try {
-      const stat = posixSnapshotZipFs.statSync(args[0])
-      if (stat.isDirectory()) return 1
-      return 0
+      const stat = posixSnapshotZipFs.statSync(statPath)
+      if (stat.isDirectory()) result = 1
+      else result = 0
     } catch (e) {
-      return -constants.ENOENT
+      result = -constants.ENOENT
     }
+    log(`internalModuleStat ${result} ${statPath}`)
+    return result
   }
 
   lazyRestoreFs = () => {


### PR DESCRIPTION
**What this PR does / why we need it**:

Node 22 altered the signature for `internaModuleStat` binding, - passing the context as as arg0 and the path as arg1.

This should handle both calls

**Which issue(s) this PR fixes**: 

Fixes # #1119
